### PR TITLE
Per-container-instance allocator proof of concept

### DIFF
--- a/include/stc/ccommon.h
+++ b/include/stc/ccommon.h
@@ -76,8 +76,8 @@
 #endif
 #define c_malloc(sz)            malloc(c_i2u(sz))
 #define c_calloc(n, sz)         calloc(c_i2u(n), c_i2u(sz))
-#define c_realloc(p, sz)        realloc(p, c_i2u(sz))
-#define c_free(p)               free(p)
+#define c_realloc(p, sz, ...)        realloc(p, c_i2u(sz))
+#define c_free(p, ...)               free(p)
 #define c_delete(T, ptr)        do { T *_tp = ptr; T##_drop(_tp); free(_tp); } while (0)
 
 #define c_static_assert(b)      ((int)(0*sizeof(int[(b) ? 1 : -1])))
@@ -114,6 +114,7 @@
 #define c_no_emplace            (1<<3)
 #define c_no_cmp                (1<<4)
 #define c_no_hash               (1<<5)
+#define c_allocator_ctx         (1<<6)
 
 /* Function macros and others */
 

--- a/include/stc/forward.h
+++ b/include/stc/forward.h
@@ -39,6 +39,7 @@
 #define forward_cpque(CX, VAL) _c_cpque_types(CX, VAL)
 #define forward_cqueue(CX, VAL) _c_cdeq_types(CX, VAL)
 #define forward_cvec(CX, VAL) _c_cvec_types(CX, VAL)
+#define forward_cvec_allocator_ctx(CX, VAL) _c_cvec_types_allocator_ctx(CX, VAL)
 
 // csview
 typedef const char csview_value;
@@ -169,6 +170,11 @@ typedef union {
     typedef VAL SELF##_value; \
     typedef struct { SELF##_value *ref, *end; } SELF##_iter; \
     typedef struct SELF { SELF##_value *data; intptr_t _len, _cap; } SELF
+
+#define _c_cvec_types_allocator_ctx(SELF, VAL) \
+    typedef VAL SELF##_value; \
+    typedef struct { SELF##_value *ref, *end; } SELF##_iter; \
+    typedef struct SELF { void *allocator_ctx; SELF##_value *data; intptr_t _len, _cap; } SELF
 
 #define _c_cpque_types(SELF, VAL) \
     typedef VAL SELF##_value; \

--- a/misc/examples/vec_allocator.c
+++ b/misc/examples/vec_allocator.c
@@ -1,0 +1,23 @@
+#include <stc/cstr.h>
+#include <stc/forward.h>
+
+
+static bool invoked = false;
+
+#define custom_malloc(sz)            malloc(c_i2u(sz))
+#define custom_calloc(n, sz)         calloc(c_i2u(n), c_i2u(sz))
+#define custom_realloc(p, sz, ctx)        ({ if (ctx != NULL) *(bool *)ctx = true; realloc(p, c_i2u(sz));})
+#define custom_free(p, ...)               free(p)
+
+#define i_val int
+#define i_allocator custom
+#define i_opt c_allocator_ctx
+#define i_tag i32
+#include <stc/cvec.h>
+
+int main()
+{
+   cvec_i32 vec = cvec_i32_init(&invoked);
+   cvec_i32_push(&vec, 123);
+   return invoked ? 0 : 1;
+}


### PR DESCRIPTION
This only covers a narrow use-case in `cvec` but should be easily applicable across the board.

It doesn't add context to the container unless requested so memory profile doesn't change.