### PR TITLE
add `cco` macro, block style coroutine definition

### DIFF
--- a/include/stc/algo/coroutine.h
+++ b/include/stc/algo/coroutine.h
@@ -76,9 +76,13 @@ enum {
     *_state = cco_state_done; \
     return ret
 
+#define cco(co) \
+    for (int *_state = &(co)->cco_state, _once=1; _once; *_state = cco_state_done, _once=0) \
+    _begin: switch (*_state) case 0:
+
 #define cco_yield(ret) \
     do { \
-        *_state = __LINE__; return ret; \
+        *_state = __LINE__; return ret; goto _begin; \
         case __LINE__:; \
     } while (0)
 

--- a/misc/examples/coread.c
+++ b/misc/examples/coread.c
@@ -13,7 +13,7 @@ struct file_read {
 
 void file_read(struct file_read* g)
 {
-    cco_begin(g)
+    cco(g) {
         g->fp = fopen(g->filename, "r");
         g->line = cstr_init();
 
@@ -23,7 +23,8 @@ void file_read(struct file_read* g)
         printf("finish\n");
         cstr_drop(&g->line);
         fclose(g->fp);
-    cco_end();
+    }
+    return;
 }
 
 int main(void)


### PR DESCRIPTION
to replace cco_begin(co) && cco_end().

```c
int task1(struct context_t *ctx) {
    cco(ctx) {
        puts("1");
        cco_yield(1);
        puts("2");
        cco_yield(2);
        puts("3");
        cco_yield(3);
    }
    puts("ending");
    return -99;
}
```