### PR TITLE
Use __attribute__((unused)) for clang too

### DIFF
--- a/include/stc/priv/linkage.h
+++ b/include/stc/priv/linkage.h
@@ -29,7 +29,7 @@
   #define STC_DEF
 #else
   #define i_static
-  #ifdef __GNUC__
+  #if defined __GNUC__ || defined __clang__
     #define STC_API static __attribute__((unused))
   #else
     #define STC_API static


### PR DESCRIPTION
Otherwise, results in warnings like

    .../STC/include\stx/../stc/cvec.h(280,1): warning: unused function 'vec_int_drop' [-Wunused-function]

At least for clang on Windows, `__clang__` is defined, but `__GNUC__` is not (as confirmed by `clang -E -dm -x c nul`).