### PR TITLE
singleheader.py fixes for Windows and newer Python

### DIFF
--- a/src/singleheader.py
+++ b/src/singleheader.py
@@ -24,14 +24,14 @@ def process_file(
 ):
     out_lines += "// ### BEGIN_FILE_INCLUDE: " + basename(file_path) + '\n'
     comment_block = False
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         for line in f:
             is_comment = comment_block
-            if re.search('/\*.*?\*/', line):
+            if re.search('/\\*.*?\\*/', line):
                 pass
-            elif re.search('^\\s*/\*', line):
+            elif re.search('^\\s*/\\*', line):
                 comment_block, is_comment = True, True
-            elif re.search('\*/', line):
+            elif re.search('\\*/', line):
                 comment_block = False
 
             if is_comment:
@@ -68,7 +68,7 @@ def process_file(
 
 
 if __name__ == "__main__":
-    with open(sys.argv[2], "w", newline='\n') as f:
+    with open(sys.argv[2], "w", newline='\n', encoding="utf-8") as f:
         print(
             process_file(
                 abspath(sys.argv[1]),


### PR DESCRIPTION
Windows assumes cp1252 resulting in:

	  ...
	  File "...\STC\src\singleheader.py", line 47, in process_file
	    process_file(
	  File "...\STC\src\singleheader.py", line 28, in process_file
	    for line in f:
	  File "C:\Program Files\Python312\Lib\encodings\cp1252.py", line 23, in decode
	    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
		   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 426: character maps to <undefined>

Additionally, `\*` seems to have changed in recent Py3 versions (?), so they need an extra backslash:

	...\STC\src\singleheader.py:30: SyntaxWarning: invalid escape sequence '\*'
	  if re.search('/\*.*?\*/', line):