### PR TITLE
Fix arc memory leak

### DIFF
--- a/docs/vec_api.md
+++ b/docs/vec_api.md
@@ -105,7 +105,7 @@ vec_X_raw           vec_X_value_drop(vec_X_value* pval);
 ## Examples
 ```c
 #define i_key int
-#define i_use_cmp // enable sorting/searhing using default <, == operators
+#define i_use_cmp // enable sorting/searching using default <, == operators
 #include "stc/vec.h"
 
 #include <stdio.h>


### PR DESCRIPTION
My attempt at fixing #81. This approach increases the memory usage of each pointed-to object by 1 byte (or more depending on how the compiler handles alignment).

The alternative approach is to do what you currently do, but in `arc_X_make()` check if the allocated counter is in exactly the wrong place and if it is re-allocate it. This would keep the internal types unchanged and save the 1 byte, but in my opinion would be rather silly.