### PR TITLE
Fix issue with cbits_resize overwriting data when shrinking

### DIFF
--- a/include/stc/cbits.h
+++ b/include/stc/cbits.h
@@ -169,7 +169,7 @@ STC_INLINE void cbits_resize(cbits* self, const intptr_t size, const bool value)
     self->_size = size;
     if (new_n >= old_n) {
         c_memset(self->buffer + old_n, -(int)value, (new_n - old_n)*8);
-        if (old_n > 0) {
+        if (old_n > 0 && osize < size) {
             uintptr_t mask = _cbits_bit(osize) - 1;
             if (value) self->buffer[old_n - 1] |= ~mask;
             else       self->buffer[old_n - 1] &= mask;


### PR DESCRIPTION
Fixes #93 

This pull request addresses an issue where `cbits_resize()` could overwrite the existing data stored in a buffer entry if the cbits object is resized down from a buffer entry-aligned size (such as 64, 128, etc), to one that is not aligned (such as 50 or 100). 

I'm not sure if this is the best approach, but it does appear to fix the issue for me. Let me know if there's anything else I need to do, or if this is not an acceptable fix.