### PR TITLE
ci: add meson build/tests with asan/ubsan/msan

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,17 +1,17 @@
-name: "Main Workflow"
+name: "CMake CI"
 on:
   pull_request:
   push:
 
 jobs:
-  build_and_test:
+  cmake-build:
     runs-on: ubuntu-latest
     env:
       CFLAGS:   -DSTC_STATIC -Wall -Wno-unused-function -ggdb3 -fsanitize=address -fsanitize=undefined -fsanitize=pointer-compare -fsanitize=pointer-subtract
       CXXFLAGS: -DSTC_STATIC -Wall -Wno-unused-function -ggdb3 -fsanitize=address -fsanitize=undefined -fsanitize=pointer-compare -fsanitize=pointer-subtract
     steps:
     - name: 'Checkout'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: 'Build & Test'
       uses: ashutoshvarma/action-cmake-build@master
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,7 @@ on:
 jobs:
   meson-build-and-tests:
     runs-on: ${{ matrix.platform }}
-    name: >-
-      Meson build + tests (${{ matrix.platform }}, ${{ matrix.mode.name }} ${{ matrix.flavor }})
+    name: ${{ matrix.platform }}, ${{ matrix.mode.name }} ${{ matrix.flavor }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,16 @@ jobs:
             extra_envs:
               CC: clang-cl
               CXX: clang-cl
+          - name: clang+msan
+            args: -Db_sanitize=memory
+            extra_envs:
+              CC: clang
+              CXX: clang++
+          - name: clang-cl+msan
+            args: -Db_sanitize=memory
+            extra_envs:
+              CC: clang-cl
+              CXX: clang-cl
         platform:
           - macos-latest
           - windows-2022
@@ -53,6 +63,15 @@ jobs:
           - platform: windows-2022
             mode:
               name: clang+sanitize
+          - platform: ubuntu-22.04
+            mode:
+              name: clang-cl+msan
+          - platform: macos-latest
+            mode:
+              name: clang-cl+msan
+          - platform: windows-2022
+            mode:
+              name: clang+msan
           # msvc
           - platform: ubuntu-22.04
             mode:
@@ -67,6 +86,10 @@ jobs:
           - platform: macos-latest
             mode:
               name: clang+sanitize
+          # msan unsupported
+          - platform: macos-latest
+            mode:
+              name: clang+msan
 
     steps:
       - name: Setup meson

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,4 +112,4 @@ jobs:
           meson compile -C build-${{ matrix.flavor }}
       - name: Running tests
         run: |
-          meson test -C build-${{ matrix.flavor }} --timeout-multiplier 3
+          meson test -C build-${{ matrix.flavor }} --timeout-multiplier 5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
           - name: sanitize
             args: >-
               "-Db_sanitize=address,undefined"
+          - name: sanitize+asanonly # For Visual Studio
+            args: -Db_sanitize=address
           - name: clang+sanitize
             args: >-
               "-Db_sanitize=address,undefined"
@@ -39,12 +41,24 @@ jobs:
           - ubuntu-22.04
 
         exclude:
+          # clang-cl
           - platform: ubuntu-22.04
             mode:
               name: clang-cl+sanitize
           - platform: macos-latest
             mode:
               name: clang-cl+sanitize
+          # msvc
+          - platform: ubuntu-22.04
+            mode:
+              name: sanitize+asanonly
+          - platform: macos-latest
+            mode:
+              name: sanitize+asanonly
+          - platform: windows-2022
+            mode:
+              name: sanitize
+          # default is clang
           - platform: macos-latest
             mode:
               name: clang+sanitize

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           - name: sanitize
             args: >-
               "-Db_sanitize=address,undefined"
+            extra_envs: {}
           - name: sanitize+asanonly # For Visual Studio
             args: -Db_sanitize=address
             extra_envs: {}
@@ -49,6 +50,9 @@ jobs:
           - platform: macos-latest
             mode:
               name: clang-cl+sanitize
+          - platform: windows-2022
+            mode:
+              name: clang+sanitize
           # msvc
           - platform: ubuntu-22.04
             mode:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,3 +113,8 @@ jobs:
       - name: Running tests
         run: |
           meson test -C build-${{ matrix.flavor }} --timeout-multiplier 5
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ${{ matrix.platform }}-${{ matrix.mode.name }}-${{ matrix.flavor }}-logs
+          path: build-${{ matrix.flavor }}/meson-logs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           - name: sanitize+asanonly # For Visual Studio
             args: -Db_sanitize=address
             extra_envs:
-              ASAN_OPTIONS: report_globals=2
+              ASAN_OPTIONS: report_globals=0:halt_on_error=1:abort_on_error=1:print_summary=1
           - name: clang+sanitize
             args: >-
               "-Db_sanitize=address,undefined"
@@ -112,6 +112,7 @@ jobs:
         run: |
           meson compile -C build-${{ matrix.flavor }}
       - name: Running tests
+        env: ${{ matrix.mode.extra_envs }}
         run: |
           meson test -C build-${{ matrix.flavor }} --timeout-multiplier 5
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  meson-build-and-tests:
+    runs-on: ${{ matrix.platform }}
+    name: >-
+      Meson build + tests (${{ matrix.platform }}, ${{ matrix.mode.name }} ${{ matrix.flavor }})
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - debug
+          - release
+        mode:
+          - { name: default, args: -Dtests=enabled }
+          - name: sanitize
+            args: >-
+              "-Db_sanitize=address,undefined"
+        platform:
+          - macos-latest
+          - windows-2022
+          - ubuntu-22.04
+
+    steps:
+      - name: Setup meson
+        run: |
+          pipx install meson ninja
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: { submodules: recursive }
+      - name: Activate MSVC and Configure
+        if: ${{ matrix.platform == 'windows-2022' }}
+        run: |
+          meson setup build-${{ matrix.flavor }} --buildtype=${{ matrix.flavor }} ${{ matrix.mode.args }} --vsenv
+      - name: Configuring
+        if: ${{ matrix.platform != 'windows-2022' }}
+        run: |
+          meson setup build-${{ matrix.flavor }} --buildtype=${{ matrix.flavor }} ${{ matrix.mode.args }}
+      - name: Building
+        run: |
+          meson compile -C build-${{ matrix.flavor }}
+      - name: Running tests
+        run: |
+          meson test -C build-${{ matrix.flavor }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,8 @@ jobs:
             extra_envs: {}
           - name: sanitize+asanonly # For Visual Studio
             args: -Db_sanitize=address
-            extra_envs: {}
+            extra_envs:
+              ASAN_OPTIONS: report_globals=2
           - name: clang+sanitize
             args: >-
               "-Db_sanitize=address,undefined"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,14 +16,38 @@ jobs:
           - debug
           - release
         mode:
-          - { name: default, args: -Dtests=enabled }
+          - name: default
+            args: -Dtests=enabled
           - name: sanitize
             args: >-
               "-Db_sanitize=address,undefined"
+          - name: clang+sanitize
+            args: >-
+              "-Db_sanitize=address,undefined"
+            extra_envs:
+              CC: clang
+              CXX: clang++
+          - name: clang-cl+sanitize
+            args: >-
+              "-Db_sanitize=address,undefined"
+            extra_envs:
+              CC: clang-cl
+              CXX: clang-cl
         platform:
           - macos-latest
           - windows-2022
           - ubuntu-22.04
+
+        exclude:
+          - platform: ubuntu-22.04
+            mode:
+              name: clang-cl+sanitize
+          - platform: macos-latest
+            mode:
+              name: clang-cl+sanitize
+          - platform: macos-latest
+            mode:
+              name: clang+sanitize
 
     steps:
       - name: Setup meson
@@ -31,7 +55,6 @@ jobs:
           pipx install meson ninja
       - name: Checkout
         uses: actions/checkout@v4
-        with: { submodules: recursive }
       - name: Activate MSVC and Configure
         if: ${{ matrix.platform == 'windows-2022' }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,4 +89,4 @@ jobs:
           meson compile -C build-${{ matrix.flavor }}
       - name: Running tests
         run: |
-          meson test -C build-${{ matrix.flavor }}
+          meson test -C build-${{ matrix.flavor }} --timeout-multiplier 3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,13 @@ jobs:
         mode:
           - name: default
             args: -Dtests=enabled
+            extra_envs: {}
           - name: sanitize
             args: >-
               "-Db_sanitize=address,undefined"
           - name: sanitize+asanonly # For Visual Studio
             args: -Db_sanitize=address
+            extra_envs: {}
           - name: clang+sanitize
             args: >-
               "-Db_sanitize=address,undefined"
@@ -71,10 +73,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Activate MSVC and Configure
         if: ${{ matrix.platform == 'windows-2022' }}
+        env: ${{ matrix.mode.extra_envs }}
         run: |
           meson setup build-${{ matrix.flavor }} --buildtype=${{ matrix.flavor }} ${{ matrix.mode.args }} --vsenv
       - name: Configuring
         if: ${{ matrix.platform != 'windows-2022' }}
+        env: ${{ matrix.mode.extra_envs }}
         run: |
           meson setup build-${{ matrix.flavor }} --buildtype=${{ matrix.flavor }} ${{ matrix.mode.args }}
       - name: Building

--- a/docs/cstr_api.md
+++ b/docs/cstr_api.md
@@ -138,7 +138,7 @@ Note that all methods with arguments `(..., const char* str, isize n)`, `n` must
 
 #### Helper methods:
 ```c
-uint64_t        cstr_hash(const cstr* self);
+size_t          cstr_hash(const cstr* self);
 int             cstr_cmp(const cstr* s1, const cstr* s2);
 bool            cstr_eq(const cstr* s1, const cstr* s2);
 int             cstr_icmp(const cstr* s1, const cstr* s2);              // utf8 case-insensitive comparison

--- a/docs/cstr_api.md
+++ b/docs/cstr_api.md
@@ -138,7 +138,7 @@ Note that all methods with arguments `(..., const char* str, isize n)`, `n` must
 
 #### Helper methods:
 ```c
-size_t          cstr_hash(const cstr* self);
+uint64_t        cstr_hash(const cstr* self);
 int             cstr_cmp(const cstr* s1, const cstr* s2);
 bool            cstr_eq(const cstr* s1, const cstr* s2);
 int             cstr_icmp(const cstr* s1, const cstr* s2);              // utf8 case-insensitive comparison

--- a/include/stc/priv/cstr_prv.c
+++ b/include/stc/priv/cstr_prv.c
@@ -23,7 +23,7 @@
 #ifndef STC_CSTR_CORE_INCLUDED
 #define STC_CSTR_CORE_INCLUDED
 
-uint64_t cstr_hash(const cstr *self) {
+size_t cstr_hash(const cstr *self) {
     csview sv = cstr_sv(self);
     return c_hash_n(sv.buf, sv.size);
 }

--- a/include/stc/priv/cstr_prv.h
+++ b/include/stc/priv/cstr_prv.h
@@ -76,7 +76,7 @@ extern  bool        cstr_getdelim(cstr *self, int delim, FILE *fp);
 extern  void        cstr_erase(cstr* self, isize pos, isize len);
 extern  isize       cstr_append_fmt(cstr* self, const char* fmt, ...);
 extern  isize       cstr_printf(cstr* self, const char* fmt, ...);
-extern  size_t      cstr_hash(const cstr *self);
+extern  uint64_t    cstr_hash(const cstr *self);
 extern  bool        cstr_u8_valid(const cstr* self);
 extern  void        cstr_u8_erase(cstr* self, isize u8pos, isize u8len);
 

--- a/include/stc/priv/cstr_prv.h
+++ b/include/stc/priv/cstr_prv.h
@@ -26,6 +26,7 @@
 
 #include <stdio.h> /* FILE*, vsnprintf */
 #include <stdlib.h> /* malloc */
+#include <stddef.h> /* size_t */
 /**************************** PRIVATE API **********************************/
 
 #if defined __GNUC__ && !defined __clang__
@@ -76,7 +77,7 @@ extern  bool        cstr_getdelim(cstr *self, int delim, FILE *fp);
 extern  void        cstr_erase(cstr* self, isize pos, isize len);
 extern  isize       cstr_append_fmt(cstr* self, const char* fmt, ...);
 extern  isize       cstr_printf(cstr* self, const char* fmt, ...);
-extern  uint64_t    cstr_hash(const cstr *self);
+extern  size_t      cstr_hash(const cstr *self);
 extern  bool        cstr_u8_valid(const cstr* self);
 extern  void        cstr_u8_erase(cstr* self, isize u8pos, isize u8len);
 

--- a/include/stc/stack.h
+++ b/include/stc/stack.h
@@ -29,6 +29,7 @@
 #include "common.h"
 #include "types.h"
 #include <stdlib.h>
+#include <stdio.h>
 #endif // STC_STACK_H_INCLUDED
 
 #ifndef _i_prefix
@@ -68,6 +69,7 @@ STC_INLINE Self _c_MEMB(_with_size)(isize size, _m_value null) {
 #endif // i_capacity
 
 STC_INLINE void _c_MEMB(_clear)(Self* self) {
+    if (self->size == 0) return;
     _m_value *p = self->data + self->size;
     while (p-- != self->data) { i_keydrop(p); }
     self->size = 0;

--- a/include/stc/stack.h
+++ b/include/stc/stack.h
@@ -29,7 +29,6 @@
 #include "common.h"
 #include "types.h"
 #include <stdlib.h>
-#include <stdio.h>
 #endif // STC_STACK_H_INCLUDED
 
 #ifndef _i_prefix

--- a/misc/tests/ctest.h
+++ b/misc/tests/ctest.h
@@ -92,7 +92,11 @@ struct ctest {
 #define CTEST_IMPL_TEARDOWN_TPNAME(sname, tname) CTEST_IMPL_NAME(sname##_##tname##_teardown_ptr)
 
 #ifdef __APPLE__
+#ifdef __arm64__
+#define CTEST_IMPL_SECTION __attribute__ ((used, section ("__DATA, .ctest"), aligned(8)))
+#else
 #define CTEST_IMPL_SECTION __attribute__ ((used, section ("__DATA, .ctest"), aligned(1)))
+#endif
 #elif !defined _MSC_VER
 #define CTEST_IMPL_SECTION __attribute__ ((used, section (".ctest"), aligned(1)))
 #else

--- a/misc/tests/ctest.h
+++ b/misc/tests/ctest.h
@@ -100,11 +100,12 @@ struct ctest {
 #elif !defined _MSC_VER
 #define CTEST_IMPL_SECTION __attribute__ ((used, section (".ctest"), aligned(1)))
 #else
-#define CTEST_IMPL_SECTION
+#pragma section(".ctest", read)
+#define CTEST_IMPL_SECTION __declspec(allocate(".ctest")) __declspec(align(1))
 #endif
 
 #define CTEST_IMPL_STRUCT(sname, tname, tskip, tdata, tsetup, tteardown) \
-    static struct ctest CTEST_IMPL_TNAME(sname, tname) CTEST_IMPL_SECTION = { \
+    static CTEST_IMPL_SECTION struct ctest CTEST_IMPL_TNAME(sname, tname) = { \
         0xBADCAFE0, 0, \
         #sname, \
         #tname, \


### PR DESCRIPTION
Notes:

- msan is not supported on gcc
- msvc has limited support - namely on globals + ctest

Additional smoke tests that are not in this PR - let me know if you're interested in any of them:

- doesn't cover tcc/chibicc - they require manual builds
- doesn't cover clang static checks - out of scope & need clang tooling configuration
- doesn't cover mingw native/cross builds
- doesn't cover zig cc (clang + cross tuples) builds
- code coverage integration