### PR TITLE
fix coption_get bug at strncmp

### DIFF
--- a/include/stc/coption.h
+++ b/include/stc/coption.h
@@ -129,7 +129,7 @@ static int coption_get(coption *opt, int argc, char *argv[],
             const coption_long *o = 0, *o_exact = 0, *o_partial = 0;
             for (j = 2; argv[opt->_i][j] != '\0' && argv[opt->_i][j] != '='; ++j) {} /* find the end of the option name */
             for (k = 0; longopts[k].name != 0; ++k)
-                if (strncmp(&argv[opt->_i][2], longopts[k].name, (size_t)(j - 2)) == 0) {
+                if (strcmp(&argv[opt->_i][2], longopts[k].name) == 0) {
                     if (longopts[k].name[j - 2] == 0) ++n_exact, o_exact = &longopts[k];
                     else ++n_partial, o_partial = &longopts[k];
                 }


### PR DESCRIPTION
bug: 
"command --aa" will match  coption_long longopts[] = { { "aaaa", coption_no_argument, 'a' }, {0}}
at:
[if (strncmp(&argv[opt->_i][2], longopts[k].name, (size_t)(j - 2)) == 0)](https://github.com/stclib/STC/blob/19501aacdcb9ed90618fd494e353d8ff65a4210c/include/stc/coption.h#L132)