### PR TITLE
Implement hex number range in char-class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Folders
 stuff/*
+build_*/
 
 # Prerequisites
 *.d

--- a/include/stc/priv/cregex_prv.c
+++ b/include/stc/priv/cregex_prv.c
@@ -210,13 +210,7 @@ chartorune(_Rune *rune, const char *s)
 {
     utf8_decode_t ctx = {.state=0};
     const uint8_t *b = (const uint8_t*)s;
-    do { utf8_decode(&ctx, *b++); } while (ctx.state && ctx.state != 12);
-    if (ctx.state == 12) {
-        // 12 is the trap state which means invalid utf8 sequence, to resume
-        // we skip the current byte.
-        *rune = (uint8_t)*s;
-        return 1;
-    }
+    do { utf8_decode(&ctx, *b++); } while (ctx.state);
     *rune = ctx.codep;
     return (int)((const char*)b - s);
 }

--- a/include/stc/priv/utf8_prv.h
+++ b/include/stc/priv/utf8_prv.h
@@ -110,8 +110,9 @@ STC_INLINE uint32_t utf8_decode(utf8_decode_t* d, const uint32_t byte) {
 
 STC_INLINE uint32_t utf8_peek(const char* s) {
     utf8_decode_t d = {.state=0};
-    do { utf8_decode(&d, (uint8_t)*s++); } while (d.state);
-    return d.codep;
+    uint8_t c = (uint8_t)*s;
+    do { utf8_decode(&d, (uint8_t)*s++); } while (d.state && d.state != 12);
+    return d.state == 12 ? c : d.codep;
 }
 
 /* case-insensitive utf8 string comparison */

--- a/include/stc/priv/utf8_prv.h
+++ b/include/stc/priv/utf8_prv.h
@@ -110,9 +110,8 @@ STC_INLINE uint32_t utf8_decode(utf8_decode_t* d, const uint32_t byte) {
 
 STC_INLINE uint32_t utf8_peek(const char* s) {
     utf8_decode_t d = {.state=0};
-    uint8_t c = (uint8_t)*s;
-    do { utf8_decode(&d, (uint8_t)*s++); } while (d.state && d.state != 12);
-    return d.state == 12 ? c : d.codep;
+    do { utf8_decode(&d, (uint8_t)*s++); } while (d.state);
+    return d.codep;
 }
 
 /* case-insensitive utf8 string comparison */

--- a/tests/cregex_test.c
+++ b/tests/cregex_test.c
@@ -300,21 +300,12 @@ TEST(cregex, replace)
     }
 }
 
-TEST(cregex, utf8_string)
+TEST(cregex, hex_range_char_class)
 {
     EXPECT_EQ(cregex_make("\\x{12", 0).error, CREG_UNMATCHEDRIGHTPARENTHESIS);
 
     csview match[16];
-    EXPECT_EQ(cregex_match_aio("\xC8\x80", "\xC8\x80", match), CREG_OK);
-    EXPECT_EQ(cregex_match_aio("\xC8\x80", " \xC8\x80 ", match), CREG_OK);
-    EXPECT_EQ(cregex_match_aio("\xC8", "\xC8\x80", match), CREG_NOMATCH);
-    EXPECT_EQ(cregex_match_aio("\\x{C8}\\x{80}", "\xC8\x80", match), CREG_NOMATCH);
-    EXPECT_EQ(cregex_match_aio("\\x{0200}", "\xC8\x80", match), CREG_OK);
-    EXPECT_EQ(cregex_match_aio("[\\x{0100}-\\x{0200}]", "\xC8\x80", match), CREG_OK);
-    EXPECT_EQ(cregex_match_aio("[\\x{0100}-\\x{0200}]", "\xC8\x81", match), CREG_NOMATCH);
-
-    const char *bad = "this is bad \xE0\xC0 string";
-    EXPECT_EQ(cregex_match_aio("bad.*string", bad, match), CREG_OK);
-    EXPECT_EQ(cregex_match_aio("bad [\\x{C8}\\x{80}\\x{E0}\\x{C0}]+ string", bad, match), CREG_OK);
-    EXPECT_EQ(cregex_match_aio("bad [\xC8\x80\xE0\xC0]+ string", bad, match), CREG_OK);
+    EXPECT_EQ(cregex_match_aio("[\\x{0100}-\\x{0200}]", "aĂb", match), CREG_OK);
+    EXPECT_EQ(cregex_match_aio("[\\x{0100}-\\x{0200}]", "ȁbc", match), CREG_NOMATCH);
+    EXPECT_EQ(cregex_match_aio("[\\x{0100}-\\x{0200}\\x{1}-\\x{7f}]", "ȁbc", match), CREG_OK);
 }


### PR DESCRIPTION
This PR
1. fixs the infinite loop bug in `chartorune` when `s` contains invalid UTF8 code sequence, which makes the decoding state machine trapped in state 12, and `*b++` ultimately advance beyond the memory boundary;
2. implement `\x{HEX}` parsing in `_nextc`, so we can write `abc[\x{D800}-\x{DFFF}]def` in char-class now.