### PR TITLE
Fix undefined memmove cloning empty vector

### DIFF
--- a/include/stc/vec.h
+++ b/include/stc/vec.h
@@ -313,7 +313,8 @@ _c_MEMB(_insert_uninit)(Self* self, const isize idx, const isize n) {
             return _c_MEMB(_end)(self);
 
     _m_value* pos = self->data + idx;
-    c_memmove(pos + n, pos, (self->size - idx)*c_sizeof *pos);
+    if (self->capacity)
+        c_memmove(pos + n, pos, (self->size - idx)*c_sizeof *pos);
     self->size += n;
     return c_literal(_m_iter){pos, self->data + self->size};
 }

--- a/include/stc/vec.h
+++ b/include/stc/vec.h
@@ -308,17 +308,12 @@ _c_MEMB(_resize)(Self* self, const isize len, _m_value null) {
 
 STC_DEF _m_iter
 _c_MEMB(_insert_uninit)(Self* self, const isize idx, const isize n) {
-    if (self->size + n > self->capacity)
-        if (!_c_MEMB(_reserve)(self, self->size*3/2 + n))
+    if (self->size + n >= self->capacity)
+        if (!_c_MEMB(_reserve)(self, self->size*3/2 + n + 2))
             return _c_MEMB(_end)(self);
 
-    _m_value *pos;
-    if (self->data == NULL)
-        pos = self->data;
-    else {
-        pos = self->data + idx;
-        c_memmove(pos + n, pos, (self->size - idx)*c_sizeof *pos);
-    }
+    _m_value *pos = self->data + idx;
+    c_memmove(pos + n, pos, (self->size - idx)*c_sizeof *pos);
     self->size += n;
     return c_literal(_m_iter){pos, self->data + self->size};
 }

--- a/include/stc/vec.h
+++ b/include/stc/vec.h
@@ -308,7 +308,7 @@ _c_MEMB(_resize)(Self* self, const isize len, _m_value null) {
 
 STC_DEF _m_iter
 _c_MEMB(_insert_uninit)(Self* self, const isize idx, const isize n) {
-    if (self->size + n >= self->capacity)
+    if (self->size + n > self->capacity)
         if (!_c_MEMB(_reserve)(self, self->size*3/2 + n))
             return _c_MEMB(_end)(self);
 

--- a/include/stc/vec.h
+++ b/include/stc/vec.h
@@ -308,13 +308,17 @@ _c_MEMB(_resize)(Self* self, const isize len, _m_value null) {
 
 STC_DEF _m_iter
 _c_MEMB(_insert_uninit)(Self* self, const isize idx, const isize n) {
-    if (self->size + n > self->capacity)
+    if (self->size + n >= self->capacity)
         if (!_c_MEMB(_reserve)(self, self->size*3/2 + n))
             return _c_MEMB(_end)(self);
 
-    _m_value* pos = self->data + idx;
-    if (self->capacity)
+    _m_value *pos;
+    if (self->data == NULL)
+        pos = self->data;
+    else {
+        pos = self->data + idx;
         c_memmove(pos + n, pos, (self->size - idx)*c_sizeof *pos);
+    }
     self->size += n;
     return c_literal(_m_iter){pos, self->data + self->size};
 }


### PR DESCRIPTION
Example:
```c
#include <stdio.h>

#define i_type IntVec, int
#include "stc/vec.h"

int main() {
    IntVec v = IntVec_init();
    IntVec_push(&v, 5);
    printf("v size: %ld capacity: %ld data: %p\n", v.size, v.capacity,
           (void *)v.data);
    IntVec_pop(&v);
    printf("v size: %ld capacity: %ld data: %p\n", v.size, v.capacity,
           (void *)v.data);
    IntVec w = IntVec_clone(v);
    printf("w size: %ld capacity: %ld data: %p\n", w.size, w.capacity,
           (void *)w.data);
    IntVec_drop(&v);
}
```
`clang-analyzer` notes that the memmove on line 316 of `vec.h` might be called with a null argument. In this case, it is, since `v` has size of zero, so nothing is reserved for the new vector and so it is never `realloc`ed. Compile with `-fsanitize=undefined`:
```
v size: 1 capacity: 4 data: 0x64ac5410c2b0
v size: 0 capacity: 4 data: 0x64ac5410c2b0
/home/rous/.local/include/stc/vec.h:316:5: runtime error: null pointer passed as argument 1, which is declared to never be null
/home/rous/.local/include/stc/vec.h:316:5: runtime error: null pointer passed as argument 2, which is declared to never be null
w size: 0 capacity: 0 data: (nil)
```
This was fixed by checking if the capacity is zero before doing the `memmove`.