### PR TITLE
TCC support in options, examples and no atomic types.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Folders
 stuff/*
-build_*/
+build*/
 
 # Prerequisites
 *.d

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq ($(origin CXX),default)
 	CXX := g++
 endif
 
-CFLAGS 	  ?= -std=c11 -Iinclude -MMD -O3 -Wpedantic -Wall -Wextra -Werror -Wno-missing-field-initializers
+CFLAGS    ?= -std=c11 -Iinclude -MMD -O3 -Wpedantic -Wall -Wextra -Werror -Wno-missing-field-initializers
 CXXFLAGS  ?= -std=c++20 -Iinclude -O3 -MMD -Wall
 LDFLAGS   ?= -fopenmp
 ifeq ($(CC),tcc)
@@ -64,11 +64,12 @@ all: $(PROGRAMS)
 $(PROGRAMS): $(LIB_PATH) $(MAKEFILE)
 
 clean:
-	@$(RM_F) $(LIB_OBJS) $(TEST_OBJS) $(EX_OBJS) $(LIB_DEPS) $(EX_DEPS) $(LIB_PATH) $(EX_EXES) $(TEST_EXE)
+	@$(RM_F) $(LIB_OBJS) $(EX_OBJS) $(TEST_OBJS) $(LIB_DEPS) $(EX_DEPS) $(TEST_DEPS) $(LIB_PATH) $(EX_EXES) $(TEST_EXE)
 	@echo "Cleaned"
 
 distclean:
-	$(RM_F) $(OBJ_DIR)
+	@$(RM_F) -r build_*
+	@echo "All Cleaned"
 
 lib: $(LIB_PATH)
 

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ RM_F      ?= rm -f
 
 ifeq ($(OS),Windows_NT)
 	DOTEXE := .exe
-	BUILDDIR := build_Windows/$(CC)
+	BUILDDIR := build/Windows_$(CC)
 else
 #	CC_VER := $(shell $(CC) -dumpversion | cut -f1 -d.)
-	BUILDDIR := build_$(shell uname)/$(CC)
+	BUILDDIR := build/$(shell uname)_$(CC)
 	LDFLAGS += -lm
 	ifneq ($(CC),clang)
 	  CFLAGS += -Wno-clobbered
@@ -68,10 +68,11 @@ clean:
 	@echo "Cleaned"
 
 distclean:
-	@$(RM_F) -r build_*
+	@$(RM_F) -r build
 	@echo "All Cleaned"
 
 lib: $(LIB_PATH)
+	@echo
 
 $(LIB_PATH): $(LIB_OBJS)
 	@printf "\r\e[2K%s" "$(AR_RCS) $@"

--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,12 @@ LIB_PATH  := $(BUILDDIR)/lib$(LIB_NAME).a
 EX_SRCS   := $(wildcard examples/*/*.c)
 EX_OBJS   := $(EX_SRCS:%.c=$(OBJ_DIR)/%.o)
 EX_DEPS   := $(EX_SRCS:%.c=$(OBJ_DIR)/%.d)
-EX_EXES   := $(EX_SRCS:%.c=$(OBJ_DIR)/%$(DOTEXE))
+EX_EXES   := $(EX_SRCS:%.c=$(BUILDDIR)/%$(DOTEXE))
 
 TEST_SRCS   := $(wildcard tests/*_test.c) tests/main.c
 TEST_OBJS   := $(TEST_SRCS:%.c=$(OBJ_DIR)/%.o)
 TEST_DEPS   := $(TEST_SRCS:%.c=$(OBJ_DIR)/%.d)
-TEST_EXE    := $(OBJ_DIR)/tests/test_all$(DOTEXE)
+TEST_EXE    := $(BUILDDIR)/tests/test_all$(DOTEXE)
 
 PROGRAMS	:= $(EX_EXES) $(TEST_EXE)
 

--- a/Makefile
+++ b/Makefile
@@ -11,17 +11,16 @@ ifeq ($(origin CXX),default)
 	CXX := g++
 endif
 
-ifeq ($(CC),tcc)
-  AR_RCS  ?= tcc -ar rcs
-  OPT_MD  ?= -MD
-else
-  AR_RCS  ?= ar rcs
-  OPT_MD  ?= -MMD
-endif
-CFLAGS    ?= -std=c11 -Iinclude $(OPT_MD) -O3 -Wpedantic -Wall -Wextra -Werror -Wno-missing-field-initializers -DSUPRESS_NONATOMIC_WARNING
+CFLAGS    ?= -std=c11 -Iinclude -O3 -Wpedantic -Wall -Wextra -Werror -Wno-missing-field-initializers -DSUPRESS_NONATOMIC_WARNING
 CXXFLAGS  ?= -std=c++20 -Iinclude -O3 -MMD -Wall
 LDFLAGS   ?= -fopenmp
-
+ifeq ($(CC),tcc)
+  AR_RCS  ?= tcc -ar rcs
+  CFLAGS  += -MD
+else
+  AR_RCS  ?= ar rcs
+  CFLAGS  += -MMD
+endif
 MKDIR_P   ?= mkdir -p
 RM_F      ?= rm -f
 

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,17 @@ ifeq ($(origin CXX),default)
 	CXX := g++
 endif
 
-CFLAGS    ?= -std=c11 -Iinclude -MMD -O3 -Wpedantic -Wall -Wextra -Werror -Wno-missing-field-initializers
-CXXFLAGS  ?= -std=c++20 -Iinclude -O3 -MMD -Wall
-LDFLAGS   ?= -fopenmp
 ifeq ($(CC),tcc)
   AR_RCS  ?= tcc -ar rcs
+  OPT_MD  ?= -MD
 else
   AR_RCS  ?= ar rcs
+  OPT_MD  ?= -MMD
 endif
+CFLAGS    ?= -std=c11 -Iinclude $(OPT_MD) -O3 -Wpedantic -Wall -Wextra -Wno-missing-field-initializers
+CXXFLAGS  ?= -std=c++20 -Iinclude -O3 -MMD -Wall
+LDFLAGS   ?= -fopenmp
+
 MKDIR_P   ?= mkdir -p
 RM_F      ?= rm -f
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else
   AR_RCS  ?= ar rcs
   OPT_MD  ?= -MMD
 endif
-CFLAGS    ?= -std=c11 -Iinclude $(OPT_MD) -O3 -Wpedantic -Wall -Wextra -Wno-missing-field-initializers
+CFLAGS    ?= -std=c11 -Iinclude $(OPT_MD) -O3 -Wpedantic -Wall -Wextra -Werror -Wno-missing-field-initializers -DSUPRESS_NONATOMIC_WARNING
 CXXFLAGS  ?= -std=c++20 -Iinclude -O3 -MMD -Wall
 LDFLAGS   ?= -fopenmp
 

--- a/examples/hashmaps/birthday.c
+++ b/examples/hashmaps/birthday.c
@@ -18,7 +18,7 @@ static void test_repeats(void)
     crand64 rng = crand64_from(seed);
 
     hmap_ui m = hmap_ui_with_capacity(N);
-    const LOG2E = 1/log(2);
+    const int LOG2E = 1/log(2);
     for (c_range(i, N)) {
         uint64_t k = crand64_uint_r(&rng, 1) & mask;
         int v = hmap_ui_insert(&m, k, 0).ref->second += 1;

--- a/examples/hashmaps/birthday.c
+++ b/examples/hashmaps/birthday.c
@@ -18,11 +18,12 @@ static void test_repeats(void)
     crand64 rng = crand64_from(seed);
 
     hmap_ui m = hmap_ui_with_capacity(N);
+    const LOG2E = 1/log(2);
     for (c_range(i, N)) {
         uint64_t k = crand64_uint_r(&rng, 1) & mask;
         int v = hmap_ui_insert(&m, k, 0).ref->second += 1;
         if (v > 1) printf("repeated value %" PRIu64 " (%d) at 2^%d\n",
-                          k, v, (int)log2((double)i));
+                          k, v, (int)(log((double)i))*LOG2E);
     }
     hmap_ui_drop(&m);
 }

--- a/include/stc/arc.h
+++ b/include/stc/arc.h
@@ -59,6 +59,24 @@ int main(void) {
 #include "common.h"
 #include <stdlib.h>
 
+#ifndef _i_prefix
+  #define _i_prefix arc_
+#endif
+#define _i_is_arc
+#include "priv/template.h"
+typedef i_keyraw _m_raw;
+
+#if c_OPTION(c_no_atomic)
+  #define i_no_atomic
+#endif
+
+#if (!defined i_no_atomic || (defined (__STDC_VERSION__) && __STDC_VERSION__ < 201112L)) \
+    && !(defined __GNUC__ || defined __clang__ || defined _MSC_VER)
+#warning ISO C99 dose not support atomic types, arc will degenerate to rc. \
+Suppression warning by option `c_no_atomic` or define `i_no_automic`.
+#define i_no_atomic
+#endif
+
 #if defined __GNUC__ || defined __clang__ || defined _MSC_VER || defined i_no_atomic
     typedef long catomic_long;
 #else // try with C11
@@ -68,7 +86,7 @@ int main(void) {
     #include <intrin.h>
     #define c_atomic_inc(v) (void)_InterlockedIncrement(v)
     #define c_atomic_dec_and_test(v) !_InterlockedDecrement(v)
-#elif defined __GNUC__ || defined __clang__
+#elif defined __GNUC__ || defined __clang__ || defined i_no_atomic
     #define c_atomic_inc(v) (void)__atomic_add_fetch(v, 1, __ATOMIC_SEQ_CST)
     #define c_atomic_dec_and_test(v) !__atomic_sub_fetch(v, 1, __ATOMIC_SEQ_CST)
 #else // try with C11
@@ -81,16 +99,6 @@ int main(void) {
 struct _arc_metadata { catomic_long counter; };
 #endif // STC_ARC_H_INCLUDED
 
-#ifndef _i_prefix
-  #define _i_prefix arc_
-#endif
-#define _i_is_arc
-#include "priv/template.h"
-typedef i_keyraw _m_raw;
-
-#if c_OPTION(c_no_atomic)
-  #define i_no_atomic
-#endif
 #if !defined i_no_atomic
   #define _i_atomic_inc(v)          c_atomic_inc(v)
   #define _i_atomic_dec_and_test(v) c_atomic_dec_and_test(v)

--- a/include/stc/arc.h
+++ b/include/stc/arc.h
@@ -71,9 +71,11 @@ typedef i_keyraw _m_raw;
 #endif
 
 #if (!defined i_no_atomic || (defined (__STDC_VERSION__) && __STDC_VERSION__ < 201112L)) \
-    && !(defined __GNUC__ || defined __clang__ || defined _MSC_VER) && !defined SUPRESS_NONATOMIC_WARNING
+    && !(defined __GNUC__ || defined __clang__ || defined _MSC_VER)
+#ifndef SUPRESS_NONATOMIC_WARNING
 #warning ISO C99 dose not support atomic types, arc will degenerate to rc. \
 Suppression warning by option `c_no_atomic` or define `i_no_automic` or define `SUPRESS_NONATOMIC_WARNING`.
+#endif
 #define i_no_atomic
 #endif
 

--- a/include/stc/arc.h
+++ b/include/stc/arc.h
@@ -88,10 +88,10 @@ Suppression warning by option `c_no_atomic` or define `i_no_automic` or define `
     #include <intrin.h>
     #define c_atomic_inc(v) (void)_InterlockedIncrement(v)
     #define c_atomic_dec_and_test(v) !_InterlockedDecrement(v)
-#elif defined __GNUC__ || defined __clang__ || defined i_no_atomic
+#elif defined __GNUC__ || defined __clang__
     #define c_atomic_inc(v) (void)__atomic_add_fetch(v, 1, __ATOMIC_SEQ_CST)
     #define c_atomic_dec_and_test(v) !__atomic_sub_fetch(v, 1, __ATOMIC_SEQ_CST)
-#else // try with C11
+#elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
     #include <stdatomic.h>
     #define c_atomic_inc(v) (void)atomic_fetch_add(v, 1)
     #define c_atomic_dec_and_test(v) (atomic_fetch_sub(v, 1) == 1)

--- a/include/stc/arc.h
+++ b/include/stc/arc.h
@@ -71,9 +71,9 @@ typedef i_keyraw _m_raw;
 #endif
 
 #if (!defined i_no_atomic || (defined (__STDC_VERSION__) && __STDC_VERSION__ < 201112L)) \
-    && !(defined __GNUC__ || defined __clang__ || defined _MSC_VER)
+    && !(defined __GNUC__ || defined __clang__ || defined _MSC_VER) && !defined SUPRESS_NONATOMIC_WARNING
 #warning ISO C99 dose not support atomic types, arc will degenerate to rc. \
-Suppression warning by option `c_no_atomic` or define `i_no_automic`.
+Suppression warning by option `c_no_atomic` or define `i_no_automic` or define `SUPRESS_NONATOMIC_WARNING`.
 #define i_no_atomic
 #endif
 


### PR DESCRIPTION
TCC does not support option `-MMD`.(#131)
When using tcc, switch to `-MD`.

TCC does not support atomic types.
When arc is used in C99 without compiler extensions, a warning is given that atomic reference counting is not supported and will degenerate to normal reference counting.