### PR TITLE
fixed issue where cstr_init wasnt setting to 0 correctly

### DIFF
--- a/include/stc/types.h
+++ b/include/stc/types.h
@@ -88,7 +88,7 @@ typedef union {
 typedef char cstr_value;
 typedef struct { cstr_value* data; intptr_t size, cap; } cstr_buf;
 typedef union cstr {
-    cstr_buf _dummy;
+    struct { cstr_buf *a, *b, *c; } _dummy;
     struct { cstr_value* data; uintptr_t size; uintptr_t ncap; } lon;
     struct { cstr_value data[ sizeof(cstr_buf) - 1 ]; uint8_t size; } sml;
 } cstr;

--- a/include/stc/types.h
+++ b/include/stc/types.h
@@ -88,7 +88,7 @@ typedef union {
 typedef char cstr_value;
 typedef struct { cstr_value* data; intptr_t size, cap; } cstr_buf;
 typedef union cstr {
-    cstr_buf* _dummy;
+    cstr_buf _dummy;
     struct { cstr_value* data; uintptr_t size; uintptr_t ncap; } lon;
     struct { cstr_value data[ sizeof(cstr_buf) - 1 ]; uint8_t size; } sml;
 } cstr;


### PR DESCRIPTION
The first member of `cstr` was a pointer when (I think) it's supposed to be `cstr_buf` by value.

I was getting an error where `cstr_init` was only setting the first 8 bytes (matching `cstr_buf* _dummy`) to 0, while the rest 16 bytes was uninitialized.

I think this is because `{0}` on unions is not required by the standard to set the whole union to zero, just the first variant.