### PR TITLE
added i_included check to generic containers that can use it

### DIFF
--- a/include/stc/deque.h
+++ b/include/stc/deque.h
@@ -41,6 +41,8 @@
 #undef _pop
 #undef _pull
 
+#ifndef i_included
+
 STC_API _m_value*   _c_MEMB(_push_front)(Self* self, _m_value value);
 STC_API _m_iter     _c_MEMB(_insert_n)(Self* self, isize idx, const _m_value* arr, isize n);
 STC_API _m_iter     _c_MEMB(_insert_uninit)(Self* self, isize idx, isize n);
@@ -124,6 +126,8 @@ _c_MEMB(_find)(const Self* self, _m_raw raw) {
 #if defined _i_has_cmp
 #include "priv/sort_prv.h"
 #endif // _i_has_cmp
+
+#endif // i_included
 
 /* -------------------------- IMPLEMENTATION ------------------------- */
 #if defined i_implement

--- a/include/stc/hmap.h
+++ b/include/stc/hmap.h
@@ -72,6 +72,13 @@ struct hmap_meta { uint16_t hashx:6, dist:10; }; // dist: 0=empty, 1=PSL 0, 2=PS
 #endif
 #define _i_is_hash
 #include "priv/template.h"
+
+#ifndef i_max_load_factor
+    #define i_max_load_factor 0.80f
+#endif
+
+#ifndef i_included
+
 #ifndef i_declared
   _c_DEFTYPES(_declare_htable, Self, i_key, i_val, _i_MAP_ONLY, _i_SET_ONLY, _i_aux_def);
 #endif
@@ -107,10 +114,6 @@ STC_INLINE bool         _c_MEMB(_contains)(const Self* self, _m_keyraw rkey)
                             { return self->size && _c_MEMB(_bucket_lookup_)(self, &rkey).ref; }
 STC_INLINE void         _c_MEMB(_shrink_to_fit)(Self* self)
                             { _c_MEMB(_reserve)(self, (isize)self->size); }
-
-#ifndef i_max_load_factor
-  #define i_max_load_factor 0.80f
-#endif
 
 STC_INLINE _m_result
 _c_MEMB(_insert_entry_)(Self* self, _m_keyraw rkey) {
@@ -300,6 +303,8 @@ _c_MEMB(_eq)(const Self* self, const Self* other) {
     }
     return true;
 }
+
+#endif // i_included
 
 /* -------------------------- IMPLEMENTATION ------------------------- */
 #if defined i_implement

--- a/include/stc/list.h
+++ b/include/stc/list.h
@@ -86,6 +86,9 @@
 #include "priv/template.h"
 
 #define _i_is_list
+
+#ifndef i_included
+
 #ifndef i_declared
   _c_DEFTYPES(_declare_list, Self, i_key, _i_aux_def);
 #endif
@@ -223,6 +226,8 @@ STC_INLINE bool _c_MEMB(_eq)(const Self* self, const Self* other) {
     return !(i.ref || j.ref);
 }
 #endif
+
+#endif // i_included
 
 // -------------------------- IMPLEMENTATION -------------------------
 #if defined i_implement

--- a/include/stc/pqueue.h
+++ b/include/stc/pqueue.h
@@ -34,6 +34,9 @@
 #endif
 #define _i_sorted
 #include "priv/template.h"
+
+#ifndef i_included
+
 #ifndef i_declared
   _c_DEFTYPES(_declare_stack, Self, i_key, _i_aux_def);
 #endif
@@ -123,6 +126,8 @@ STC_INLINE _m_value _c_MEMB(_value_clone)(const Self* self, _m_value val)
 STC_INLINE void _c_MEMB(_emplace)(Self* self, _m_raw raw)
     { _c_MEMB(_push)(self, i_keyfrom(raw)); }
 #endif // !i_no_emplace
+
+#endif // i_included
 
 /* -------------------------- IMPLEMENTATION ------------------------- */
 #if defined i_implement

--- a/include/stc/priv/linkage.h
+++ b/include/stc/priv/linkage.h
@@ -23,6 +23,10 @@
 #undef STC_API
 #undef STC_DEF
 
+#if defined(i_included)
+#define i_implement
+#define i_declared
+#endif
 #if !defined i_static && !defined STC_STATIC && (defined i_header || defined STC_HEADER  || \
                                                  defined i_implement || defined STC_IMPLEMENT)
   #define STC_API extern

--- a/include/stc/priv/linkage2.h
+++ b/include/stc/priv/linkage2.h
@@ -34,6 +34,7 @@
 #undef i_header
 #undef i_implement
 #undef i_import
+#undef i_included
 
 #if defined __clang__ && !defined __cplusplus
   #pragma clang diagnostic pop

--- a/include/stc/priv/queue_prv.h
+++ b/include/stc/priv/queue_prv.h
@@ -22,6 +22,9 @@
  */
 
 // IWYU pragma: private
+
+#ifndef i_included
+
 #ifndef i_declared
 _c_DEFTYPES(_declare_queue, Self, i_key, _i_aux_def);
 #endif
@@ -171,6 +174,8 @@ STC_INLINE isize _c_MEMB(_index)(const Self* self, _m_iter it)
 
 STC_INLINE void _c_MEMB(_adjust_end_)(Self* self, isize n)
     { self->end = (self->end + n) & self->capmask; }
+
+#endif // i_included
 
 /* -------------------------- IMPLEMENTATION ------------------------- */
 #if defined i_implement

--- a/include/stc/smap.h
+++ b/include/stc/smap.h
@@ -70,6 +70,9 @@ int main(void) {
 #endif
 #define _i_sorted
 #include "priv/template.h"
+
+#ifndef i_included
+
 #ifndef i_declared
   _c_DEFTYPES(_declare_aatree, Self, i_key, i_val, _i_MAP_ONLY, _i_SET_ONLY, _i_aux_def);
 #endif
@@ -260,6 +263,8 @@ STC_INLINE Self _c_MEMB(_from_n)(const _m_raw* raw, isize n)
 STC_INLINE Self _c_MEMB(_with_capacity)(const isize cap)
     { Self cx = {0}; _c_MEMB(_reserve)(&cx, cap); return cx; }
 #endif
+
+#endif // i_included
 
 /* -------------------------- IMPLEMENTATION ------------------------- */
 #if defined i_implement

--- a/include/stc/stack.h
+++ b/include/stc/stack.h
@@ -25,6 +25,10 @@
 
 // Stack - a simplified vec type without linear search and insert/erase inside the stack.
 
+#ifdef i_included
+#error "Stack is fully static inline"
+#endif
+
 #ifndef STC_STACK_H_INCLUDED
 #define STC_STACK_H_INCLUDED
 #include "common.h"

--- a/include/stc/vec.h
+++ b/include/stc/vec.h
@@ -73,6 +73,8 @@ int main(void) {
 #endif
 #include "priv/template.h"
 
+#ifndef i_included
+
 #ifndef i_declared
    _c_DEFTYPES(_declare_stack, Self, i_key, _i_aux_def);
 #endif
@@ -262,6 +264,7 @@ STC_INLINE bool _c_MEMB(_eq)(const Self* self, const Self* other) {
 #include "priv/sort_prv.h"
 #endif // _i_has_cmp
 
+#endif // i_included
 /* -------------------------- IMPLEMENTATION ------------------------- */
 #if defined i_implement
 


### PR DESCRIPTION
I'm working on a project and faced this problem:

```
// my_object.h
#ifndef MY_OBJECT_H
#define MY_OBJECT_H

typedef struct MyObject {
    int n;
} MyObject;

#define T Objects, MyObject
#define i_header
#include "stc/vec.h"

#define T NameObjectMap, char*, MyObject
#define i_header
#include "stc/hashmap.h"

#endif
```

```
// my_object.c
#include "my_object.h"

#define T Objects, MyObject
#define i_declared
#define i_implement
#include "stc/vec.h" // error because redefinition of static inline functions

#define T NameObjectMap, char*, MyObject
#define i_declared
#define i_implement
#include "stc/hashmap.h" // same error
```

In my project I have many headers that make a new type, and create containers for it and expose the APIs to those containers.

The only solution is to make a header file per container, or make one big header that defines all the containers and a matching .c that implements all the containers (which is not ideal, because including this big header means including most headers in the project).

So I implemented `i_included`. It just means that the container was included with `i_header` previously, so don't repeat `static inline` definitions, type definitions, or any declarations, only paste the implementation.

`i_included` implies `i_implement` and `i_declared` are also true.

now my_object.c can look like this:
```
// my_object.c
#include "my_object.h"

#define T Objects, MyObject
#define i_included
#include "stc/vec.h"

#define T NameObjectMap, char*, MyObject
#define i_included
#include "stc/hashmap.h"
```

I also thought of calling it `i_implement_only`.

I was confused as what to do with `stack.h`. the whole API is `static inline`, so reincluding it makes no sense. So I just `#error` if `i_included` is defined (I don't know if that's the best approach)

# TLDR:
`i_included` allows re-including a container if the first include is `i_header`.
The second include will only paste implementation.
