### PR TITLE
Binary search on utf8 case folding

### DIFF
--- a/include/stc/priv/utf8_prv.c
+++ b/include/stc/priv/utf8_prv.c
@@ -113,7 +113,6 @@ uint32_t utf8_tolower(uint32_t c) {
     if (i < n) {
         const struct CaseMapping entry = casemappings[upcase_ind[i]];
         if (entry.c1 <= c && c <= entry.c2) {
-            if (c < entry.c1) return c;
             int d = entry.m2 - entry.c2;
             if (d == 1) return c + ((entry.c2 & 1U) == (c & 1U));
             return (uint32_t)((int)c + d);
@@ -134,7 +133,6 @@ uint32_t utf8_toupper(uint32_t c) {
         const struct CaseMapping entry = casemappings[lowcase_ind[i]];
         int d = entry.m2 - entry.c2;
         if (entry.c1 + (uint32_t)d <= c && c <= entry.m2) {
-            if (c < (uint32_t)(entry.c1 + d)) return c;
             if (d == 1) return c - ((entry.m2 & 1U) == (c & 1U));
             return (uint32_t)((int)c - d);
         }

--- a/include/stc/priv/utf8_prv.c
+++ b/include/stc/priv/utf8_prv.c
@@ -86,22 +86,33 @@ bool utf8_valid_n(const char* s, isize nbytes) {
 }
 
 uint32_t utf8_casefold(uint32_t c) {
-    for (int i=0; i < casefold_len; ++i) {
+    int i = 0, j = casefold_len;
+    while (i < j) {
+        int mid = (i + j) / 2;
+        if (c < casemappings[mid].c2) j = mid;
+        else if (c == casemappings[mid].c2) i = j = mid; // leads to break
+        else i = mid + 1;
+    }
+    if (i < casefold_len && casemappings[i].c1 <= c && c <= casemappings[i].c2) {
         const struct CaseMapping entry = casemappings[i];
-        if (c <= entry.c2) {
-            if (c < entry.c1) return c;
-            int d = entry.m2 - entry.c2;
-            if (d == 1) return c + ((entry.c2 & 1U) == (c & 1U));
-            return (uint32_t)((int)c + d);
-        }
+        int d = entry.m2 - entry.c2;
+        if (d == 1) return c + ((entry.c2 & 1U) == (c & 1U));
+        return (uint32_t)((int)c + d);
     }
     return c;
 }
 
 uint32_t utf8_tolower(uint32_t c) {
-    for (int i=0; i < (int)(sizeof upcase_ind/sizeof *upcase_ind); ++i) {
+    int n = sizeof upcase_ind/sizeof *upcase_ind, i = 0, j = n;
+    while (i < j) {
+        int mid = (i + j) / 2;
+        if (c < casemappings[upcase_ind[mid]].c2) j = mid;
+        else if (c == casemappings[upcase_ind[mid]].c2) i = j = mid; // leads to break
+        else i = mid + 1;
+    }
+    if (i < n) {
         const struct CaseMapping entry = casemappings[upcase_ind[i]];
-        if (c <= entry.c2) {
+        if (entry.c1 <= c && c <= entry.c2) {
             if (c < entry.c1) return c;
             int d = entry.m2 - entry.c2;
             if (d == 1) return c + ((entry.c2 & 1U) == (c & 1U));
@@ -112,10 +123,17 @@ uint32_t utf8_tolower(uint32_t c) {
 }
 
 uint32_t utf8_toupper(uint32_t c) {
-    for (int i=0; i < (int)(sizeof lowcase_ind/sizeof *lowcase_ind); ++i) {
+    int n = sizeof lowcase_ind/sizeof *lowcase_ind, i = 0, j = n;
+    while (i < j) {
+        int mid = (i + j) / 2;
+        if (c < casemappings[lowcase_ind[mid]].m2) j = mid;
+        else if (c == casemappings[lowcase_ind[mid]].m2) i = j = mid; // leads to break
+        else i = mid + 1;
+    }
+    if (i < n) {
         const struct CaseMapping entry = casemappings[lowcase_ind[i]];
-        if (c <= entry.m2) {
-            int d = entry.m2 - entry.c2;
+        int d = entry.m2 - entry.c2;
+        if (entry.c1 + (uint32_t)d <= c && c <= entry.m2) {
             if (c < (uint32_t)(entry.c1 + d)) return c;
             if (d == 1) return c - ((entry.m2 & 1U) == (c & 1U));
             return (uint32_t)((int)c - d);

--- a/tests/utf8_test.c
+++ b/tests/utf8_test.c
@@ -1,0 +1,81 @@
+#include <stc/cstr.h>
+#include <stc/utf8.h>
+#include <stc/csview.h>
+#include <stc/coroutine.h>
+#include "ctest.h"
+
+static uint32_t utf8_casefold_bruteforce(uint32_t c) {
+    for (int i=0; i < casefold_len; ++i) {
+        const struct CaseMapping entry = casemappings[i];
+        if (c <= entry.c2) {
+            if (c < entry.c1) return c;
+            int d = entry.m2 - entry.c2;
+            if (d == 1) return c + ((entry.c2 & 1U) == (c & 1U));
+            return (uint32_t)((int)c + d);
+        }
+    }
+    return c;
+}
+
+static uint32_t utf8_tolower_bruteforce(uint32_t c) {
+    for (int i=0; i < (int)(sizeof upcase_ind/sizeof *upcase_ind); ++i) {
+        const struct CaseMapping entry = casemappings[upcase_ind[i]];
+        if (c <= entry.c2) {
+            if (c < entry.c1) return c;
+            int d = entry.m2 - entry.c2;
+            if (d == 1) return c + ((entry.c2 & 1U) == (c & 1U));
+            return (uint32_t)((int)c + d);
+        }
+    }
+    return c;
+}
+
+static uint32_t utf8_toupper_bruteforce(uint32_t c) {
+    for (int i=0; i < (int)(sizeof lowcase_ind/sizeof *lowcase_ind); ++i) {
+        const struct CaseMapping entry = casemappings[lowcase_ind[i]];
+        if (c <= entry.m2) {
+            int d = entry.m2 - entry.c2;
+            if (c < (uint32_t)(entry.c1 + d)) return c;
+            if (d == 1) return c - ((entry.m2 & 1U) == (c & 1U));
+            return (uint32_t)((int)c - d);
+        }
+    }
+    return c;
+}
+
+TEST(utf8, utf8_casefold)
+{
+    for (unsigned ch = 0; ch < 0x20000; ++ch)
+        EXPECT_EQ(utf8_casefold(ch), utf8_casefold_bruteforce(ch));
+}
+
+TEST(utf8, utf8_tolower)
+{
+    for (unsigned ch = 0; ch < 0x20000; ++ch)
+        EXPECT_EQ(utf8_tolower(ch), utf8_tolower_bruteforce(ch));
+}
+
+TEST(utf8, utf8_toupper)
+{
+    for (unsigned ch = 0; ch < 0x20000; ++ch)
+        EXPECT_EQ(utf8_toupper(ch), utf8_toupper_bruteforce(ch));
+}
+
+#if 0
+TEST(utf8, bench_utf8_casefold)
+{
+    long long t = cco_ticks();
+    int repeats = 500;
+    for (int i = 0; i < repeats; i++)
+        for (unsigned ch = 1; ch < 65536; ++ch)
+            EXPECT_TRUE(utf8_casefold(ch));
+    printf("binary=%lldus\n", (cco_ticks() - t) / repeats);
+
+    t = cco_ticks();
+    repeats = 100;
+    for (int i = 0; i < repeats; i++)
+        for (unsigned ch = 1; ch < 65536; ++ch)
+            EXPECT_TRUE(utf8_casefold_bruteforce(ch));
+    printf("bruteforce=%lldus\n", (cco_ticks() - t) / repeats);
+}
+#endif


### PR DESCRIPTION
Binary search on utf8 casemappings for better performance. A little not-so-strict benchmark is added in `tests/utf8_test.c` (disabled by #if 0), reporting 5-10x faster.