### PR TITLE
Add the missing finalize.h header to meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -105,6 +105,7 @@ install_headers(
 install_headers(
   'include/stc/sys/crange.h',
   'include/stc/sys/filter.h',
+  'include/stc/sys/finalize.h',
   'include/stc/sys/sumtype.h',
   'include/stc/sys/utility.h',
   subdir: 'stc/sys',


### PR DESCRIPTION
I'm pretty sure this header was supposed to be copied to the include dir during install. Correct me if I'm wrong.