### PR TITLE
added struct tags for all declared structs 

### DIFF
--- a/include/stc/types.h
+++ b/include/stc/types.h
@@ -146,7 +146,7 @@ typedef const char* cstr_raw;
         AUXDEF \
     } SELF; \
 \
-    typedef struct { \
+    typedef struct SELF##_iter { \
         SELF##_value *ref; \
         ptrdiff_t pos; \
         const SELF* _s; \
@@ -156,7 +156,7 @@ typedef const char* cstr_raw;
     typedef VAL SELF##_value; \
     typedef struct SELF##_node SELF##_node; \
 \
-    typedef struct { \
+    typedef struct SELF##_iter { \
         SELF##_value *ref; \
         SELF##_node *const *_last, *prev; \
     } SELF##_iter; \
@@ -174,7 +174,7 @@ typedef const char* cstr_raw;
             MAP_ONLY( struct SELF##_value ) \
     SELF##_value, SELF##_entry; \
 \
-    typedef struct { \
+    typedef struct SELF##_result { \
         SELF##_value *ref; \
         size_t idx; \
         bool inserted; \
@@ -182,7 +182,7 @@ typedef const char* cstr_raw;
         uint16_t dist; \
     } SELF##_result; \
 \
-    typedef struct { \
+    typedef struct SELF##_iter { \
         SELF##_value *ref, *_end; \
         struct hmap_meta *_mref; \
     } SELF##_iter; \
@@ -203,12 +203,12 @@ typedef const char* cstr_raw;
             MAP_ONLY( struct SELF##_value ) \
     SELF##_value, SELF##_entry; \
 \
-    typedef struct { \
+    typedef struct SELF##_result { \
         SELF##_value *ref; \
         bool inserted; \
     } SELF##_result; \
 \
-    typedef struct { \
+    typedef struct SELF##_iter { \
         SELF##_value *ref; \
         SELF##_node *_d; \
         int _top; \
@@ -228,7 +228,7 @@ typedef const char* cstr_raw;
 
 #define _declare_stack(SELF, VAL, AUXDEF) \
     typedef VAL SELF##_value; \
-    typedef struct { SELF##_value *ref, *end; } SELF##_iter; \
+    typedef struct SELF##_iter { SELF##_value *ref, *end; } SELF##_iter; \
     typedef struct SELF { SELF##_value *data; ptrdiff_t size, capacity; AUXDEF } SELF
 
 #endif // STC_TYPES_H_INCLUDED


### PR DESCRIPTION
This is so that `declare_*` macros work in C23 without needing `i_declared`.

For example, this code did not work because structs like the `_iter` and `_result` structs do not have tags, and what happens is the two declarations declare the same `typedef` name, but two anonymous structs, so they are not compatible. adding a tag fixes it, because in C23 re-declaring the same struct with the same tag is allowed.
```C
#include "stc/types.h"

// vec
declare_vec(Vec, int);

#define T Vec, int
#include "stc/vec.h"

// list
declare_list(List, int);

#define T List, int
#include "stc/list.h"

// queue

declare_queue(Queue, int);

#define T Queue, int
#include "stc/queue.h"

// hashset

declare_hashset(Set, int);

#define T Set, int
#include "stc/hashset.h"

// sortedset

declare_sortedset(SortedSet, int);

#define T SortedSet, int
#include "stc/sortedset.h"

```